### PR TITLE
Code for v3.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,4 @@ COPY main.py .
 COPY utils ./utils
 COPY apod ./apod
 
-RUN zdump /etc/localtime
-
 ENTRYPOINT python3 main.py $MODE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM python:3
 
+ENV TZ America/New_York
 ENV MODE prod
 ENV VENV /opt/venv
+
+# Set timezone
+RUN ln -fs /usr/share/zoneinfo/$TZ /etc/localtime && dpkg-reconfigure -f noninteractive tzdata
 
 # Setup environment
 WORKDIR .
 RUN mkdir ./logs
+
 
 # Setup virtual environment
 RUN python3 -m venv $VENV
@@ -19,5 +24,7 @@ RUN pip install -r requirements.txt
 COPY main.py .
 COPY utils ./utils
 COPY apod ./apod
+
+RUN zdump /etc/localtime
 
 ENTRYPOINT python3 main.py $MODE


### PR DESCRIPTION
Fix for `/today` and `/apod` commands using the next day's date due to the container timezone. Set the timezone in the Dockerfile.